### PR TITLE
Use property access syntax in documentation

### DIFF
--- a/USAGE_CORE.md
+++ b/USAGE_CORE.md
@@ -17,7 +17,7 @@ protected void onCreate(Bundle savedInstanceState) {
 kotlin
 ```kotlin
 override fun onCreate(savedInstanceState: Bundle) {
-    getLayoutInflater().setIconicsFactory(getDelegate())
+    layoutInflater.setIconicsFactory(delegate)
     //...
     super.onCreate(savedInstanceState)
     //...


### PR DESCRIPTION
Small documentation change for setting the Iconics inflater: usage of Kotlin property access syntax instead of java getters